### PR TITLE
webapp: Add separate runner component type

### DIFF
--- a/webapp/src/api/types.ts
+++ b/webapp/src/api/types.ts
@@ -11,6 +11,9 @@ export type SummaryType = {
 export type ComponentType = {
   id: string;
   name: string;
+  type:
+    | "runner"
+    | "service";
   status:
     | "operational"
     | "degradedPerformance"
@@ -21,6 +24,13 @@ export type ComponentType = {
   rawData: string;
   updatedAt: string;
 };
+
+export type RunnerComponentType = ComponentType & {
+  pendingRunnerCount: number;
+  runningRunnerCount: number;
+};
+
+export type ServiceComponentType = ComponentType;
 
 export type IncidentType = {
   id: string;

--- a/webapp/src/app/components/components/Components.tsx
+++ b/webapp/src/app/components/components/Components.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useData } from "@/api/client";
-import { Component } from "./Component";
+import { RunnerComponent } from "./RunnerComponent";
+import { ServiceComponent } from "./ServiceComponent";
 import styled from "styled-components";
 import { Summary } from "./Summary";
 import { Skeleton } from "./Skeleton";
 import { Stack } from "../Stack";
+import { RunnerComponentType, ServiceComponentType } from "@/api/types";
 
 const Card = styled.div`
   box-shadow: 0px 0px 33px -32px rgba(0, 0, 0, 0.75);
@@ -14,14 +16,21 @@ const Card = styled.div`
   padding: 16px;
 `;
 
+const CategoryTitle = styled.h3`
+  color: ${(props) => props.theme.colors.text};
+`;
+
 export const Components = () => {
   const { components, loading } = useData();
+  const runnerComponents = components?.filter((component) => component.type == "runner");
+  const serviceComponents = components?.filter((component) => component.type == "service");
 
   return (
     <Card>
       {!loading ? (
         <Summary components={components} />
       ) : null}
+      <CategoryTitle>Runners</CategoryTitle>
       <Stack>
         {loading ? (
           <>
@@ -30,8 +39,22 @@ export const Components = () => {
             <Skeleton />
           </>
         ) : (
-          components.map((component) => (
-            <Component key={component.id} {...component} />
+          runnerComponents?.map((component) => (
+            <RunnerComponent key={component.id} {...component as RunnerComponentType} />
+          ))
+        )}
+      </Stack>
+      <CategoryTitle>Services</CategoryTitle>
+      <Stack>
+        {loading ? (
+          <>
+            <Skeleton />
+            <Skeleton />
+            <Skeleton />
+          </>
+        ) : (
+          serviceComponents?.map((component) => (
+            <ServiceComponent key={component.id} {...component as ServiceComponentType} />
           ))
         )}
       </Stack>

--- a/webapp/src/app/components/components/RunnerComponent.tsx
+++ b/webapp/src/app/components/components/RunnerComponent.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import { RunnerComponentType } from "@/api/types";
+import styled from "styled-components";
+import { Badge } from "./Badge";
+
+const Box = styled.div`
+  background-color: ${(props) => props.theme.colors.body};
+  padding: 8px 16px;
+  border-radius: 3px;
+  justify-content: space-between;
+  align-items: center;
+  display: flex;
+  color: ${(props) => props.theme.colors.text};
+  cursor: pointer;
+`;
+
+const Overlay = styled.div`
+  background-color: rgba(0, 0, 0, 0.5);
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 999;
+`;
+
+const Popup = styled.div`
+  background-color: ${(props) => props.theme.colors.body};
+  color: ${(props) => props.theme.colors.text};
+  border-radius: 8px;
+  min-width: 50vw;
+  top: 50%;
+  left: 50%;
+  padding: 20px;
+  position: absolute;
+  transform: translateX(-50%) translateY(-50%);
+`;
+
+const Terminal = styled.div`
+  background-color: black;
+  color: white;
+  padding: 20px;
+  overflow-y: auto;
+  overflow-x: auto;
+  max-width: 80vw;
+  max-height: 80vh;
+  font-family: monospace;
+  white-space: pre;
+`;
+
+const RunnerTitle = styled.div`
+  font-weight: 500;
+  padding-bottom: 5px;
+`;
+
+const RunnerState = styled.div`
+  color: ${(props) => props.theme.colors.hintText};
+  font-size: 14px;
+`;
+
+export const RunnerComponent = ({ name, status, runningRunnerCount, pendingRunnerCount, rawData, updatedAt }: RunnerComponentType) => {
+  const [showRawData, setShowRawData] = useState(false);
+
+  return (
+    <div>
+      <Box onClick={() => setShowRawData(true)}>
+        <div>
+          <RunnerTitle>{name}</RunnerTitle>
+          <RunnerState>{runningRunnerCount ?? 0} running, {pendingRunnerCount ?? 0} pending</RunnerState>
+        </div>
+        <Badge status={status} updatedAt={updatedAt} />
+      </Box>
+
+      {showRawData &&
+        <Overlay onClick={() => setShowRawData(false)}>
+          <Popup onClick={(e) => e.stopPropagation()}>
+            <Terminal>{rawData}</Terminal>
+          </Popup>
+        </Overlay>
+      }
+    </div>
+    );
+}

--- a/webapp/src/app/components/components/ServiceComponent.tsx
+++ b/webapp/src/app/components/components/ServiceComponent.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { ComponentType } from "@/api/types";
+import { ServiceComponentType } from "@/api/types";
 import styled from "styled-components";
 import { Badge } from "./Badge";
 
@@ -48,7 +48,7 @@ const Terminal = styled.div`
   white-space: pre;
 `;
 
-export const Component = ({ name, status, rawData, updatedAt }: ComponentType) => {
+export const ServiceComponent = ({ name, status, rawData, updatedAt }: ServiceComponentType) => {
   const [showRawData, setShowRawData] = useState(false);
 
   return (

--- a/webapp/src/providers/zephyr.ts
+++ b/webapp/src/providers/zephyr.ts
@@ -9,82 +9,98 @@ const components = [
   {
     id: "9",
     name: "HZR Kubernetes Cluster",
+    type: "service",
     source: `${componentSourceBase}/status.hzr_kubernetes_cluster.json`,
   },
   {
     id: "10",
     name: "CNX Kubernetes Cluster",
+    type: "service",
     source: `${componentSourceBase}/status.cnx_kubernetes_cluster.json`,
   },
   {
     id: "11",
     name: "AWS Kubernetes Cluster",
+    type: "service",
     source: `${componentSourceBase}/status.aws_kubernetes_cluster.json`,
   },
   {
     id: "49",
     name: "HZR KeyDB Cache",
+    type: "service",
     source: `${componentSourceBase}/status.hzr_keydb_cache.json`,
   },
   {
     id: "50",
     name: "CNX KeyDB Cache",
+    type: "service",
     source: `${componentSourceBase}/status.cnx_keydb_cache.json`,
   },
   {
     id: "99",
     name: "HZR Actions Runner Controller",
+    type: "service",
     source: `${componentSourceBase}/status.hzr_actions_runner_controller.json`,
   },
   {
     id: "100",
     name: "CNX Actions Runner Controller",
+    type: "service",
     source: `${componentSourceBase}/status.cnx_actions_runner_controller.json`,
   },
   {
     id: "101",
     name: "AWS Actions Runner Controller",
+    type: "service",
     source: `${componentSourceBase}/status.aws_actions_runner_controller.json`,
-  },
-  {
-    id: "105",
-    name: "HZR Runner Scale Set: linux-arm64-4xlarge",
-    source: `${componentSourceBase}/status.hzr_runner_scale_set-linux_arm64_4xlarge.json`,
-  },
-  {
-    id: "106",
-    name: "HZR Runner Scale Set: linux-x64-4xlarge",
-    source: `${componentSourceBase}/status.hzr_runner_scale_set-linux_x64_4xlarge.json`,
-  },
-  {
-    id: "110",
-    name: "CNX Runner Scale Set: linux-arm64-4xlarge",
-    source: `${componentSourceBase}/status.cnx_runner_scale_set-linux_arm64_4xlarge.json`,
-  },
-  {
-    id: "111",
-    name: "CNX Runner Scale Set: linux-x64-4xlarge",
-    source: `${componentSourceBase}/status.cnx_runner_scale_set-linux_x64_4xlarge.json`,
-  },
-  {
-    id: "120",
-    name: "AWS Runner Scale Set: linux-arm64-4xlarge",
-    source: `${componentSourceBase}/status.aws_runner_scale_set-linux_arm64_4xlarge.json`,
-  },
-  {
-    id: "121",
-    name: "AWS Runner Scale Set: linux-x64-4xlarge",
-    source: `${componentSourceBase}/status.aws_runner_scale_set-linux_x64_4xlarge.json`,
   },
   {
     id: "300",
     name: "Elasticsearch",
+    type: "service",
     source: `${componentSourceBase}/status.aws_elasticsearch.json`,
   },
   {
     id: "301",
     name: "Kibana",
+    type: "service",
     source: `${componentSourceBase}/status.aws_kibana.json`,
+  },
+  {
+    id: "1100",
+    name: "HZR Runner Scale Set: linux-arm64-4xlarge",
+    type: "runner",
+    source: `${componentSourceBase}/status.hzr_runner_scale_set-linux_arm64_4xlarge.json`,
+  },
+  {
+    id: "1101",
+    name: "HZR Runner Scale Set: linux-x64-4xlarge",
+    type: "runner",
+    source: `${componentSourceBase}/status.hzr_runner_scale_set-linux_x64_4xlarge.json`,
+  },
+  {
+    id: "1200",
+    name: "CNX Runner Scale Set: linux-arm64-4xlarge",
+    type: "runner",
+    source: `${componentSourceBase}/status.cnx_runner_scale_set-linux_arm64_4xlarge.json`,
+  },
+  {
+    id: "1201",
+    name: "CNX Runner Scale Set: linux-x64-4xlarge",
+    type: "runner",
+    source: `${componentSourceBase}/status.cnx_runner_scale_set-linux_x64_4xlarge.json`,
+  },
+  {
+    id: "1300",
+    name: "AWS Runner Scale Set: linux-arm64-4xlarge",
+    type: "runner",
+    source: `${componentSourceBase}/status.aws_runner_scale_set-linux_arm64_4xlarge.json`,
+  },
+  {
+    id: "1301",
+    name: "AWS Runner Scale Set: linux-x64-4xlarge",
+    type: "runner",
+    source: `${componentSourceBase}/status.aws_runner_scale_set-linux_x64_4xlarge.json`,
   },
 ];
 
@@ -105,6 +121,7 @@ export const zephyrProvider: Provider = {
       return {
         id: component.id,
         name: component.name,
+        type: component.type,
         ...data
       };
     }));


### PR DESCRIPTION
This commit reworks the status components such that they are organised into two categories: runners and services.

The runner status components, in addition to the operating state, feature running and pending runner counts.